### PR TITLE
Skip chmod of postCreateCommand.sh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,5 +31,5 @@
     }
   },
 
-  "postCreateCommand": "chmod +x ./.devcontainer/postCreateCommand.sh && ./.devcontainer/postCreateCommand.sh"
+  "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh"
 }


### PR DESCRIPTION
The postCreateCommand.sh is already executable in git as checked in here, and so `chmod` isn't needed. But even if it were, just running the script with `bash` is probably nicer.